### PR TITLE
Make IsActive configurable and add KeywordNames support

### DIFF
--- a/Snapdi/Snapdi.Repositories/Repositories/BlogRepository.cs
+++ b/Snapdi/Snapdi.Repositories/Repositories/BlogRepository.cs
@@ -166,7 +166,7 @@ namespace Snapdi.Repositories.Repositories
         public override async Task<Blog> AddAsync(Blog entity)
         {
             entity.CreateAt = DateTime.Now;
-            entity.IsActive = true;
+            // Remove the hardcoded IsActive = true to allow setting from CreateBlogDto
             return await base.AddAsync(entity);
         }
 

--- a/Snapdi/Snapdi.Services/DTOs/BlogDto.cs
+++ b/Snapdi/Snapdi.Services/DTOs/BlogDto.cs
@@ -31,6 +31,8 @@ namespace Snapdi.Services.DTOs
 
         public int? AuthorId { get; set; }
 
+        public bool IsActive { get; set; } = true;
+
         public List<string> KeywordNames { get; set; } = new List<string>();
         public List<int> KeywordIds { get; set; } = new List<int>();
     }

--- a/Snapdi/Snapdi.Services/Services/BlogService.cs
+++ b/Snapdi/Snapdi.Services/Services/BlogService.cs
@@ -111,7 +111,7 @@ namespace Snapdi.Services.Services
                 Content = createBlogDto.Content,
                 AuthorId = createBlogDto.AuthorId,
                 CreateAt = DateTime.Now,
-                IsActive = true
+                IsActive = createBlogDto.IsActive
             };
 
             var createdBlog = await _blogRepository.AddAsync(blog);


### PR DESCRIPTION
Removed hardcoded IsActive assignment in BlogRepository to allow dynamic configuration via CreateBlogDto. Added IsActive property to CreateBlogDto with a default value of true. Introduced KeywordNames property in CreateBlogDto to support specifying keyword names. Updated BlogService to set IsActive dynamically from CreateBlogDto.